### PR TITLE
Fix link to GitHub repo

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig({
         Head: './src/components/starlight/Head.astro',
       },
       social: {
-        github: 'https://github.com/opensourcemaintenancefee/www',
+        github: 'https://github.com/opensourcemaintenancefee/web',
       },
       sidebar: [
         {


### PR DESCRIPTION
The repo is hosted at `web`, not `www`.