### PR TITLE
fix: Text is hard to read in light mode

### DIFF
--- a/src/assets/custom.css
+++ b/src/assets/custom.css
@@ -20,6 +20,7 @@
   --sl-color-accent-high: #303B29;
   --sl-color-bg: #F2F2F2;
   --sl-color-white: var(--sl-color-accent-high);
+  --sl-color-bg-nav: #fcfff4;
 }
 
 /* Overrides */


### PR DESCRIPTION
Fixes text that is hard to read in light mode. Chose a random color that is a very light accent color.

(to prevent misunderstandings: I wouldn't dare to use light mode, but [someone on HN](https://news.ycombinator.com/item?id=44670229) noted this)